### PR TITLE
Enable "Add Existing Block" insert function to work

### DIFF
--- a/client/views/blocks/modals/existing_block.html
+++ b/client/views/blocks/modals/existing_block.html
@@ -18,7 +18,7 @@
           <tbody>
             {{#each allBlocks}}
               <tr>
-                <td><a class="btn add-existing-block">Insert</a></td>
+                <td><a class="btn add-existing-block" id="{{_id}}">Insert</a></td>
                 <td>{{template}}</td>
                 <td>{{humanReadableTime created}}</td>
                 <td><a class="preview-block"><div class="block-preview" style="display: none;">{{{renderBlock this}}}</div><i class="icon-search"></i></a></td>

--- a/client/views/blocks/modals/existing_block.js
+++ b/client/views/blocks/modals/existing_block.js
@@ -15,6 +15,8 @@ Template.existing_block.events = {
     var page = utils.getCurrentPage();
 
     var label = Template[this.template].label || 'Single Block';
+    //find the block by the (block)-id of the insert button
+    block = Blocks.findOne(e.target.id);
     // Attach the block to the page
     if (!page.notFound) {
       PageBlocks.insert({page_id: page._id, block_id: block._id, label: label, zone: Session.get('block-zone'), added: Date.now()});


### PR DESCRIPTION
The add-existing-block button got an id equal to this._id so that it can be used to find the correct block to insert in Template.existing_block.events
