### PR TITLE
move Npm.require out of package.js

### DIFF
--- a/packages/wrench/package.js
+++ b/packages/wrench/package.js
@@ -4,8 +4,6 @@ Package.describe({
 
 Npm.depends({wrench: "1.5.1"});
 
-wrench = Npm.require("wrench");
-
 Package.on_use(function (api) {
     api.add_files([
         'wrench.js'


### PR DESCRIPTION
Should only be in wrench.js. This fixes the following meteor error:

wrench: updating npm dependencies -- wrench...
=> Errors prevented startup:

While building package `wrench`:
package.js:7:14: can't find npm module 'wrench'. Did you forget to call 'Npm.depends'?
